### PR TITLE
add Docker and docker-compose setup for frontend, backend, and PostgreSQL

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY target/*.jar app.jar
+
+ENV SPRING_PROFILES_ACTIVE=default
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15
+    container_name: HamlaouiDB-Cont
+    environment:
+      POSTGRES_DB: CosmoDB
+      POSTGRES_USER: ${DATABASE_USERNAME}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - my_network
+
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: HamlaouiBackend-Cont
+    environment:
+      DATABASE_USERNAME: ${DATABASE_USERNAME}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD}
+    ports:
+      - "8081:8081"
+    depends_on:
+      - postgres
+    networks:
+      - my_network
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: HamlaouiFrontend-Cont
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+    networks:
+      - my_network
+
+volumes:
+  postgres_data:
+
+networks:
+  my_network:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+RUN npm run build
+
+CMD ["npm","run","dev","--","--host"]


### PR DESCRIPTION
This PR containerizes the full-stack application as requested in [Issue #5] https://github.com/m-elhamlaoui/development-platform-cosmotracker/issues/5. It includes:  
- *Frontend*: Dockerfile for React 
- *Backend*: Dockerfile for Spring Boot 
- *Database*: PostgreSQL container.  
- *Orchestration*: docker-compose.yml   

## Changes  
Added:  
  - frontend/Dockerfile  
  - backend/Dockerfile  
  - docker-compose.yml (with .env support for DB credentials)