### PR TITLE
Add CI/CD Pipeline with Jenkins, Docker, and SonarQube Integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,103 @@
+pipeline {
+    agent any
+
+    environment {
+        DOCKER_BUILDKIT = '1'
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Verify Structure') {
+            steps {
+                sh 'ls -la ${WORKSPACE}/backend'
+            }
+        }
+
+        stage('Run Tests') {
+            tools {
+                maven 'Maven 3'
+            }
+            steps {
+                dir('backend') {
+                    sh 'mvn test'
+                }
+            }
+        }
+
+        stage('Build Jar') {
+            tools {
+                maven 'Maven 3'
+            }
+            steps {
+                dir('backend') {
+                    sh 'mvn clean package -DskipTests'
+                }
+            }
+        }
+
+        stage('Build Docker Image') {
+            steps {
+                script {
+                    sh "docker build -t kei077/cosmo-backend:${BUILD_NUMBER} ./backend"
+                    sh "docker tag kei077/cosmo-backend:${BUILD_NUMBER} kei077/cosmo-backend:latest"
+                }
+            }
+        }
+
+        stage('Push Docker Image') {
+            steps {
+                withCredentials([usernamePassword(credentialsId: 'dockerhub-cred', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+                    sh '''
+                        echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+                        docker push kei077/cosmo-backend:${BUILD_NUMBER}
+                        docker push kei077/cosmo-backend:latest
+                    '''
+                }
+            }
+        }
+
+        stage('SonarQube Analysis') {
+            tools {
+                maven 'Maven 3'
+            }
+            steps {
+                withSonarQubeEnv('SonarQube') {
+                    withCredentials([string(credentialsId: 'SONAR_TOKEN', variable: 'SONAR_TOKEN')]) {
+                        sh """
+                            cd backend && \
+                            mvn sonar:sonar \
+                            -Dsonar.projectKey=cosmo-backend \
+                            -Dsonar.host.url=http://192.168.240.198:9000 \
+                            -Dsonar.login=$SONAR_TOKEN
+                        """
+                    }
+                }
+            }
+        }
+
+        stage('Run App') {
+            when {
+                expression { currentBuild.resultIsBetterOrEqualTo('SUCCESS') }
+            }
+            steps {
+                echo "Launching app with Docker Compose..."
+                sh 'docker-compose up -d'
+            }
+        }
+    }
+
+    post {
+        always {
+            echo "Cleaning up Docker containers..."
+            sh 'docker-compose down || true'
+        }
+        failure {
+            echo "Pipeline failed. Please check the logs above."
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a full CI/CD pipeline using Jenkins

Jenkins pipeline stages for:
  - Code checkout from repo
  - Maven tests
  - Jar build
  - Docker image build and push to dockerhub
  - Sonarqube code analysis
  - Deployment using docker compose

- Requires dockerhub credentials and Sonarqube token to be configured in Jenkins as GLOBAL CREDENTIALS
- Sonarqube server for some reason cant be configured using localhost but instead requires IP address (will try to fix this later)

I actually tested this on a separate repo, will have to make this repo public or configure token for it to work on this one though  !