### PR TITLE
add testpropertysource annotation to tests for dummy nasa api key

### DIFF
--- a/backend/src/test/java/com/cosmic/tracker/authTests/AuthRestControllerIntegrationTest.java
+++ b/backend/src/test/java/com/cosmic/tracker/authTests/AuthRestControllerIntegrationTest.java
@@ -15,6 +15,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.security.Key;
@@ -28,6 +29,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("test")
 @SpringBootTest
 @AutoConfigureMockMvc
+@TestPropertySource(properties = {
+    "NASA_API_KEY=dummy-key-for-testing"
+})
 class AuthRestControllerIntegrationTest {
 
     @Autowired

--- a/backend/src/test/java/com/cosmic/tracker/cosmicevent/CosmicEventControllerTest.java
+++ b/backend/src/test/java/com/cosmic/tracker/cosmicevent/CosmicEventControllerTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -17,6 +18,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @AutoConfigureMockMvc(addFilters = false)
 @ActiveProfiles("test")
+@TestPropertySource(properties = {
+    "NASA_API_KEY=dummy-key-for-testing"
+})
 public class CosmicEventControllerTest {
 
     @Autowired


### PR DESCRIPTION
just added testpropertysource annotation to some tests because they were failling for missing nasa api key 